### PR TITLE
feat(loan): implement Step3 openLoan transaction (amount parsing, env driven addresses)

### DIFF
--- a/web/src/components/OpenLoan.tsx
+++ b/web/src/components/OpenLoan.tsx
@@ -1,22 +1,66 @@
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { CONFIG } from '@/config'
+import { Address, isAddress, parseUnits } from 'viem'
+import { useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
+
+const LOAN_MANAGER_ABI = [
+  {
+    type: 'function',
+    name: 'openLoan',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'collection', type: 'address' },
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'amount', type: 'uint256' },
+      { name: 'currency', type: 'address' }
+    ],
+    outputs: [ { name: 'loanId', type: 'uint256' } ]
+  }
+] as const
 
 export default function OpenLoan() {
   const [loanManager, setLoanManager] = useState(CONFIG.loanManagerAddress ?? '')
   const [collection, setCollection] = useState('')
   const [tokenId, setTokenId] = useState('')
   const [currency, setCurrency] = useState('')
-  const [amount, setAmount] = useState('')
-  const [done, setDone] = useState(false)
+  const [decimals, setDecimals] = useState('6') // USDC想定デフォルト
+  const [amount, setAmount] = useState('') // 人間可読の額（例: 100.5）
+
+  const { data: hash, isPending, writeContract, error } = useWriteContract()
+  const { isLoading: isConfirming, isSuccess: isConfirmed, data: receipt } = useWaitForTransactionReceipt({ hash })
+
+  const valid = isAddress(loanManager) && isAddress(collection) && tokenId.length > 0 && isAddress(currency) && amount.length > 0 && Number(decimals) >= 0
+
+  const parsedAmount = useMemo(() => {
+    try {
+      return parseUnits(amount as `${number}`, Number(decimals))
+    } catch {
+      return undefined
+    }
+  }, [amount, decimals])
 
   function onOpen() {
-    // モック: 実コントラクト接続前のダミー成功
-    setTimeout(() => setDone(true), 400)
+    if (!valid || parsedAmount === undefined) return
+    writeContract({
+      abi: LOAN_MANAGER_ABI,
+      address: loanManager as Address,
+      functionName: 'openLoan',
+      args: [collection as Address, BigInt(tokenId), parsedAmount, currency as Address]
+    })
   }
+
+  // loanId抽出（イベントやreturn dataのdecodingがUI簡易のため困難な時はTxのlogs解析が必要）
+  const [loanId, setLoanId] = useState<string | null>(null)
+  useEffect(() => {
+    if (isConfirmed) {
+      // 簡易: EVMはreturn dataを直接取り出せないため、ここではTx成功をもって成功表示に留める
+      setLoanId('created (check explorer logs)')
+    }
+  }, [isConfirmed])
 
   return (
     <div className="card">
-      <h4>Step 3: Loan Open（モック）</h4>
+      <h4>Step 3: Loan Open</h4>
       <div className="grid" style={{ gridTemplateColumns: 'repeat(4, 1fr)' }}>
         <label>
           LoanManager
@@ -35,12 +79,21 @@ export default function OpenLoan() {
           <input placeholder="0x..." value={currency} onChange={(e) => setCurrency(e.target.value)} />
         </label>
         <label>
-          金額(USD換算)
+          金額
           <input placeholder="100" value={amount} onChange={(e) => setAmount(e.target.value)} />
         </label>
+        <label>
+          小数桁(decimals)
+          <input placeholder="6" value={decimals} onChange={(e) => setDecimals(e.target.value)} />
+        </label>
       </div>
-      <button className="primary" onClick={onOpen}>借入実行（モック）</button>
-      {done && <p style={{ color: '#10b981' }}>借入が完了した想定です</p>}
+      <button className="primary" onClick={onOpen} disabled={!valid || parsedAmount === undefined || isPending || isConfirming}>
+        {isPending || isConfirming ? '送信中...' : '借入実行を送信'}
+      </button>
+      {hash && <p style={{ color: '#9aa0a6' }}>Tx Hash: {hash}</p>}
+      {isConfirmed && <p style={{ color: '#10b981' }}>借入が確定しました（loanId: {loanId ?? '-'}）</p>}
+      {error && <p style={{ color: '#f87171' }}>{error.message}</p>}
+      {!isAddress(loanManager) && <p style={{ color: '#f59e0b' }}>環境変数 VITE_LOAN_MANAGER_ADDRESS を設定すると自動入力されます</p>}
     </div>
   )
 }

--- a/web/src/pages/Borrow.tsx
+++ b/web/src/pages/Borrow.tsx
@@ -27,7 +27,8 @@ export default function Borrow() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const canBorrow = isConnected && ready
+  // 進行要件: Step1/2 はウォレット接続のみ。Step3 以降でAave設定が必要になったら別途ガード。
+  const canProceed = isConnected
 
   async function loadRemote() {
     setLoading(true)
@@ -120,11 +121,14 @@ export default function Borrow() {
           <button className="primary" onClick={() => setActiveStep((s) => Math.max(0, s - 1))} disabled={activeStep === 0}>
             戻る
           </button>
-          <button className="primary" onClick={() => setActiveStep((s) => Math.min(steps.length - 1, s + 1))} disabled={!canBorrow || activeStep === steps.length - 1}>
+          <button className="primary" onClick={() => setActiveStep((s) => Math.min(steps.length - 1, s + 1))} disabled={!canProceed || activeStep === steps.length - 1}>
             次へ
           </button>
         </div>
-        {!canBorrow && <p style={{ color: '#9aa0a6' }}>ウォレット接続とAave Pool設定が必要です。</p>}
+        {!isConnected && <p style={{ color: '#9aa0a6' }}>ウォレット接続が必要です。</p>}
+        {activeStep === 2 && !ready && (
+          <p style={{ color: '#9aa0a6' }}>Step3（借入実行）ではAave Pool設定（VITE_AAVE_POOL_ADDRESS_BASE_SEPOLIA）が必要です。</p>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## 概要
- Step3（借入実行）の実装を追加しました。`OpenLoan` コンポーネントから `ILoanManager.openLoan(collection, tokenId, amount, currency)` を実トランザクションで呼び出します。
- 金額は `decimals` に基づいて `parseUnits` で正しくスケーリングします（例: USDC=6）。

## 変更点
- `web/src/components/OpenLoan.tsx`
  - `useWriteContract` / `useWaitForTransactionReceipt` による `openLoan` 書き込み実装
  - `amount` 入力の `decimals` 指定に対応（デフォルト6）
  - 環境変数 `VITE_LOAN_MANAGER_ADDRESS` による自動入力（未設定でもUIから上書き可）
- 既存のStep1/Step2（承認/預入）はそのまま（Step2は実Tx・確認済み）

## 環境変数
- `web/.env.local`
  - `VITE_LOAN_MANAGER_ADDRESS=0x...`（LoanManager/Mockのコントラクトアドレス）
- 参考（既存）
  - `VITE_VAULT_ADDRESS=0x...`（預入先Vault）
  - `VITE_AAVE_POOL_ADDRESS_BASE_SEPOLIA=0x...`（Step3では未必須、将来の表示用途）
  - `VITE_WALLETCONNECT_PROJECT_ID=...`
  - `VITE_FIREBASE_PROJECT_ID=aave-nft-gamification`
  - `VITE_FIREBASE_REGION=us-central1`

## 動作確認手順（Base Sepolia）
- 前提
  - Step1/Step2 で同一 `collection`/`tokenId` を使用し、Vault へ預入済み
  - `VITE_LOAN_MANAGER_ADDRESS` に `LoanManagerMock`（もしくは実LoanManager）のアドレスを設定
- 手順
  1) Borrow → Step3（Loan Open）
  2) 入力:
     - `LoanManager`: 自動入力 or 0x…
     - `コレクション`: Step2 と同じ NFT コントラクト
     - `tokenId`: Step2 と同じ
     - `通貨（USDC等）`: テスト用ERC20（任意可）
     - `金額`: 人間可読（例: 100）
     - `小数桁(decimals)`: 通貨に合わせる（例: USDC=6）
  3) 「借入実行を送信」→ ウォレット承認 → 確定
  4) Base Sepolia Explorer で Tx を確認し、`LoanOpened` イベントが出力されていることを確認
     - 例（Vault/Tx参照）:
       - Vaultアドレス（NFT Transfers）: [0xcca75Ad4…f1529b2D2](https://sepolia.basescan.org/address/0xcca75ad43668471b80a632e1823a226f1529b2d2#nfttransfers)
       - 預入Txの例: [0x418506f0…df2136b](https://sepolia.basescan.org/tx/0x418506f060998951450d4cba02377b55069c64eb468da6c97c60fc804df2136b)

## 既知の制限
- 現在は `LoanManagerMock` を利用（実装差し替え前提）。`loanId` はUIで簡易表示（Tx Logsでの確認を推奨）。
- 通貨トークンの `decimals` は手入力。将来的に自動取得（ERC20 `decimals()` 読取）に置換予定。
- Aave連携は「参照/表示」段階。実資金フローは本PRのスコープ外。

## 今後の対応
- `LoanManager` 実装への差し替え（`openLoan` の戻りやイベントから `loanId` 取得）
- 通貨 `decimals()` 自動取得、Permit2等のUX改善
- 返済UIの実装（`repay`）およびダッシュボード連携強化