### PR TITLE
feat(ui): PR-19 step2 – ガス見積のUSD表示/失敗表示をUI統合＋テスト

### DIFF
--- a/web/src/components/SmartActionPanel.tsx
+++ b/web/src/components/SmartActionPanel.tsx
@@ -1,13 +1,20 @@
 import { useMemo } from 'react'
 import { decideCta, UiState } from '@/lib/cta'
+import { GasEstimateResult } from '@/lib/gas'
 
-export default function SmartActionPanel({ state, onClick }: { state: UiState; onClick?: () => void }) {
+export default function SmartActionPanel({ state, onClick, gas }: { state: UiState; onClick?: () => void; gas?: GasEstimateResult }) {
   const decision = useMemo(() => decideCta(state), [state])
   return (
     <div className="card">
       <h3>アクション</h3>
       {decision.reason && (
         <p style={{ color: '#f59e0b', marginBottom: 8 }}>理由: {decision.reason}</p>
+      )}
+      {gas && gas.ok && (
+        <p style={{ color: '#9aa0a6', margin: 0 }}>推定手数料: ${gas.usd.toFixed(3)}</p>
+      )}
+      {gas && !gas.ok && (
+        <p style={{ color: '#f87171', margin: 0 }}>ガス見積失敗: {gas.message}</p>
       )}
       <button className="primary" disabled={decision.disabled} onClick={onClick}>
         {decision.label}

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -1,5 +1,7 @@
 export const CONFIG = {
   aavePoolAddress: (import.meta.env.VITE_AAVE_POOL_ADDRESS_BASE_SEPOLIA as string | undefined)?.toLowerCase() as `0x${string}` | undefined,
   vaultAddress: (import.meta.env.VITE_VAULT_ADDRESS as string | undefined)?.toLowerCase() as `0x${string}` | undefined,
-  loanManagerAddress: (import.meta.env.VITE_LOAN_MANAGER_ADDRESS as string | undefined)?.toLowerCase() as `0x${string}` | undefined
+  loanManagerAddress: (import.meta.env.VITE_LOAN_MANAGER_ADDRESS as string | undefined)?.toLowerCase() as `0x${string}` | undefined,
+  // USD価格は 1e8 スケール（例: $3000 => 3000 * 1e8）
+  ethUsdPrice1e8: Number(import.meta.env.VITE_ETH_USD_1E8 ?? (3000 * 1e8))
 }

--- a/web/src/lib/gas.ts
+++ b/web/src/lib/gas.ts
@@ -1,5 +1,3 @@
-import { Address } from 'viem'
-
 export type GasEstimationInput = {
   gas: bigint
   gasPrice: bigint
@@ -12,6 +10,25 @@ export function estimateUsdCost({ gas, gasPrice, ethUsdPrice1e8 }: GasEstimation
   const eth = Number(wei) / 1e18
   const usd = eth * Number(ethUsdPrice1e8) / 1e8
   return usd
+}
+
+export type GasEstimateResult =
+  | { ok: true; gas: bigint; gasPrice: bigint; usd: number }
+  | { ok: false; message: string }
+
+export async function tryEstimateTxUsd(params: {
+  estimate: () => Promise<bigint>
+  getGasPrice: () => Promise<bigint>
+  ethUsdPrice1e8: bigint
+}): Promise<GasEstimateResult> {
+  try {
+    const [gas, gasPrice] = await Promise.all([params.estimate(), params.getGasPrice()])
+    const usd = estimateUsdCost({ gas, gasPrice, ethUsdPrice1e8: params.ethUsdPrice1e8 })
+    return { ok: true, gas, gasPrice, usd }
+  } catch (e: any) {
+    const message = e?.shortMessage || e?.message || '見積りに失敗しました'
+    return { ok: false, message }
+  }
 }
 
 

--- a/web/src/pages/Borrow.tsx
+++ b/web/src/pages/Borrow.tsx
@@ -5,12 +5,13 @@ import { useAavePool } from '@/hooks/useAavePool'
 import { fetchQuoteSim } from '@/services/quote'
 import EvaluationBanner from '@/components/EvaluationBanner'
 import SmartActionPanel from '@/components/SmartActionPanel'
+import { tryEstimateTxUsd } from '@/lib/gas'
 import BorrowChecklist from '@/components/BorrowChecklist'
 import { decideCta, UiState } from '@/lib/cta'
 import { deriveChecklistState } from '@/lib/checklist'
 import { CONFIG } from '@/config'
 import { Address, isAddress, parseUnits } from 'viem'
-import { useReadContract, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
+import { usePublicClient, useReadContract, useWaitForTransactionReceipt, useWriteContract } from 'wagmi'
 
 export default function Borrow() {
   const [price1e8, setPrice1e8] = useState<number>(100_00_0000) // $100 default
@@ -23,6 +24,7 @@ export default function Borrow() {
   const { isConnected } = useAccount()
   const { address: userAddress } = useAccount()
   const { ready } = useAavePool()
+  const publicClient = usePublicClient()
 
   const quote = useMemo(() => {
     return getQuoteUSD({ price1e8, baseLTV, confidence, liquidity, volatility, debt })
@@ -127,6 +129,69 @@ export default function Borrow() {
     }
   }
 
+  // 送信前の推定手数料（USD）
+  const [gasState, setGasState] = useState<{ hashKey: string; result: ReturnType<typeof Object> | any } | null>(null)
+  useEffect(() => {
+    async function run() {
+      if (!publicClient) return
+      const d = decision
+      // 必要入力が揃わない場合はスキップ
+      if (d.disabled) { setGasState(null); return }
+      try {
+        if (d.nextStateHint === 'approve') {
+          if (!isAddress(collection) || !tokenId || !isAddress(vault)) { setGasState(null); return }
+          const hashKey = `approve:${collection}:${tokenId}:${vault}`
+          const res = await tryEstimateTxUsd({
+            estimate: () => publicClient.estimateContractGas({
+              abi: [{ type:'function', name:'approve', stateMutability:'nonpayable', inputs:[{name:'to',type:'address'},{name:'tokenId',type:'uint256'}], outputs:[] }] as const,
+              address: collection as Address,
+              functionName: 'approve',
+              args: [vault as Address, BigInt(tokenId)]
+            }),
+            getGasPrice: () => publicClient.getGasPrice(),
+            ethUsdPrice1e8: BigInt(CONFIG.ethUsdPrice1e8)
+          })
+          setGasState({ hashKey, result: res })
+        } else if (d.nextStateHint === 'deposit') {
+          if (!isAddress(vault) || !isAddress(collection) || !tokenId) { setGasState(null); return }
+          const hashKey = `deposit:${vault}:${collection}:${tokenId}`
+          const res = await tryEstimateTxUsd({
+            estimate: () => publicClient.estimateContractGas({
+              abi: [{ type:'function', name:'deposit', stateMutability:'nonpayable', inputs:[{name:'collection',type:'address'},{name:'tokenId',type:'uint256'}], outputs:[] }] as const,
+              address: vault as Address,
+              functionName: 'deposit',
+              args: [collection as Address, BigInt(tokenId)]
+            }),
+            getGasPrice: () => publicClient.getGasPrice(),
+            ethUsdPrice1e8: BigInt(CONFIG.ethUsdPrice1e8)
+          })
+          setGasState({ hashKey, result: res })
+        } else if (d.nextStateHint === 'borrow') {
+          if (!isAddress(loanManager) || !isAddress(collection) || !tokenId || !isAddress(currency) || !amount || !decimals) { setGasState(null); return }
+          let parsed
+          try { parsed = parseUnits(String(amount), Number(decimals)) } catch { setGasState(null); return }
+          const hashKey = `borrow:${loanManager}:${collection}:${tokenId}:${currency}:${parsed.toString()}`
+          const res = await tryEstimateTxUsd({
+            estimate: () => publicClient.estimateContractGas({
+              abi: [{ type:'function', name:'openLoan', stateMutability:'nonpayable', inputs:[{name:'collection',type:'address'},{name:'tokenId',type:'uint256'},{name:'amount',type:'uint256'},{name:'currency',type:'address'}], outputs:[{name:'loanId',type:'uint256'}] }] as const,
+              address: loanManager as Address,
+              functionName: 'openLoan',
+              args: [collection as Address, BigInt(tokenId), parsed, currency as Address]
+            }),
+            getGasPrice: () => publicClient.getGasPrice(),
+            ethUsdPrice1e8: BigInt(CONFIG.ethUsdPrice1e8)
+          })
+          setGasState({ hashKey, result: res })
+        } else {
+          setGasState(null)
+        }
+      } catch {
+        setGasState(null)
+      }
+    }
+    run()
+  }, [publicClient, decision, collection, tokenId, vault, loanManager, currency, amount, decimals])
+
   // Tx 成功時のローカルフラグ
   useEffect(() => {
     if (isMined && decision.nextStateHint === 'deposit') {
@@ -205,7 +270,7 @@ export default function Borrow() {
           deposited={deposited}
           evaluated={!!remote}
         />
-        <SmartActionPanel state={{ ...uiState, isApproved: approved, isDeposited: deposited }} onClick={onSmartClick} />
+        <SmartActionPanel state={{ ...uiState, isApproved: approved, isDeposited: deposited }} onClick={onSmartClick} gas={gasState?.result} />
       </div>
 
       <div className="card">

--- a/web/src/test/gas.test.ts
+++ b/web/src/test/gas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { estimateUsdCost } from '../lib/gas'
+import { estimateUsdCost, tryEstimateTxUsd } from '../lib/gas'
 
 describe('gas utils', () => {
   it('estimateUsdCost basic conversion', () => {
@@ -10,6 +10,28 @@ describe('gas utils', () => {
     // 21000 * 20 gwei = 420,000 gwei = 0.00042 ETH -> * $3000 = $1.26
     expect(usd).toBeCloseTo(1.26, 2)
   })
+})
+
+it('tryEstimateTxUsd success', async () => {
+  const res = await tryEstimateTxUsd({
+    estimate: async () => 21000n,
+    getGasPrice: async () => 20_000_000_000n,
+    ethUsdPrice1e8: 300_000_000_000n
+  } as any)
+  if (res.ok) {
+    expect(res.usd).toBeCloseTo(1.26, 2)
+  } else {
+    throw new Error('should be ok')
+  }
+})
+
+it('tryEstimateTxUsd failure', async () => {
+  const res = await tryEstimateTxUsd({
+    estimate: async () => { throw new Error('boom') },
+    getGasPrice: async () => 0n,
+    ethUsdPrice1e8: 300_000_000_000n
+  } as any)
+  expect(res.ok).toBe(false)
 })
 
 


### PR DESCRIPTION
目的\n- PR-19 続き: ガス見積(estimateContractGas)+USD表示をUIへ統合し、失敗時メッセージも提示。\n\n変更点\n- config: VITE_ETH_USD_1E8 を取り込み (デフォルト )\n- lib/gas.ts: tryEstimateTxUsd/GasEstimateResult 追加 (estimateContractGas と getGasPrice を束ねて USD換算)\n- pages/Borrow.tsx: 承認/預入/借入 各アクションの送信前にガス見積を実行し、結果を SmartActionPanel に渡す。借入数量(トークン)入力を追加。\n- components/SmartActionPanel.tsx: 推定手数料(USD)/失敗理由の表示。\n- test/gas.test.ts: 見積成功/失敗のユニットテスト追加。\n\n受け入れ基準\n- 送信前に推定手数料がUSDで表示される。\n- 見積失敗時は分かりやすい理由が表示される。\n\n備考\n- 本番では VITE_AAVE_POOL_ADDRESS_BASE_SEPOLIA と併せて VITE_ETH_USD_1E8 をビルド時に注入してください。